### PR TITLE
phi-1220 Changing VIDEO_FIRST_PLAY_REQUESTED to INITIAL_PLAYBACK_REQU…

### DIFF
--- a/js/framework/AnalyticsConstants.js
+++ b/js/framework/AnalyticsConstants.js
@@ -20,11 +20,18 @@ if (!OO.Analytics.EVENTS)
 
     /**
      * @public
-     * @event Analytics.EVENTS#VIDEO_FIRST_PLAY_REQUESTED
+     * @event Analytics.EVENTS#INITIAL_PLAYBACK_REQUESTED
      * @description This message is sent the first time the user tries to play the video.
      * In the case of autoplay, it will be sent immediately after the player is ready to play.
      */
-    VIDEO_FIRST_PLAY_REQUESTED:     'video_first_play_requested',
+    INITIAL_PLAYBACK_REQUESTED:     'initial_playback_requested',
+
+    /**
+     * @public
+     * @event Analytics.EVENTS#PLAYBACK_COMPLETED
+     * @description This message is sent when video and ad playback has completed.
+     */
+    PLAYBACK_COMPLETED:             'playback_completed',
 
     /**
      * @public
@@ -56,14 +63,6 @@ if (!OO.Analytics.EVENTS)
      * @description This message is sent when video playback has paused.
      */
     VIDEO_PAUSED:                   'video_paused',
-
-    /**
-     * @public
-     * @event Analytics.EVENTS#VIDEO_ENDED
-     * @description This message is sent when video playback has completed. This
-     * includes finishing playback of all ads.
-     */
-    VIDEO_ENDED:                    'video_ended',
 
     /**
      * @public

--- a/test/unit-tests/testAnalyticsFramework.js
+++ b/test/unit-tests/testAnalyticsFramework.js
@@ -789,7 +789,7 @@ describe('Analytics Framework Unit Tests', function()
       var factory = Utils.createFactoryWithGlobalAccessToPluginInstance();
       var pluginID = framework.registerPlugin(factory);
       var plugin = OO.Analytics.Framework.TEST[0];
-      var msg1 = EVENTS.VIDEO_FIRST_PLAY_REQUESTED;
+      var msg1 = EVENTS.INITIAL_PLAYBACK_REQUESTED;
       var msg2 = EVENTS.VIDEO_PLAY_REQUESTED;
 
       expect(framework.publishEvent(msg1)).toBe(true);
@@ -810,7 +810,7 @@ describe('Analytics Framework Unit Tests', function()
       var factory = Utils.createFactoryWithGlobalAccessToPluginInstance();
       var pluginID = framework.registerPlugin(factory);
       var plugin = OO.Analytics.Framework.TEST[0];
-      var msg1 = EVENTS.VIDEO_FIRST_PLAY_REQUESTED;
+      var msg1 = EVENTS.INITIAL_PLAYBACK_REQUESTED;
       var msg2 = EVENTS.VIDEO_PLAY_REQUESTED;
 
       expect(framework.makePluginInactive(pluginID)).toBe(true);
@@ -835,7 +835,7 @@ describe('Analytics Framework Unit Tests', function()
       var plugin1 = OO.Analytics.Framework.TEST[0];
       var plugin2 = OO.Analytics.Framework.TEST[1];
 
-      var msg1 = EVENTS.VIDEO_FIRST_PLAY_REQUESTED;
+      var msg1 = EVENTS.INITIAL_PLAYBACK_REQUESTED;
       var msg2 = EVENTS.VIDEO_PLAY_REQUESTED;
 
       //send first message successfully


### PR DESCRIPTION
…ESTED and VIDEO_ENDED to PLAYBACK_COMPLETED.  This is for clarity. VIDEO_ENDED actually meant video and ads were complete. So we renamed the initial message to match the pattern.