### PR TITLE
Pbi 1706

### DIFF
--- a/js/framework/AnalyticsFramework.js
+++ b/js/framework/AnalyticsFramework.js
@@ -214,7 +214,7 @@ OO.Analytics.Framework = function()
     {
       try
       {
-        plugin = new pluginFactory();
+        plugin = new pluginFactory(this);
       }
       catch (error)
       {

--- a/test/unit-test-helpers/AnalyticsFrameworkTestUtils.js
+++ b/test/unit-test-helpers/AnalyticsFrameworkTestUtils.js
@@ -159,4 +159,19 @@ if (!OO.Analytics.Utils)
       return badPlugin;
     },this);
   };
+
+  Utils.createFactoryToTestConstructorParams = function()
+  {
+    return OO._.bind(function(framework)
+    {
+      var validFactory = Utils.createValidPluginFactory();
+      var validPlugin = new validFactory();
+      if (!OO.Analytics.Framework.TEST)
+      {
+        OO.Analytics.Framework.TEST = {};
+        OO.Analytics.Framework.TEST.frameworkParam = framework;
+      }
+      return validPlugin;
+    },this);
+  };
 }

--- a/test/unit-tests/testAnalyticsFramework.js
+++ b/test/unit-tests/testAnalyticsFramework.js
@@ -28,6 +28,7 @@ describe('Analytics Framework Unit Tests', function()
   {
     OO.Analytics.PluginFactoryList = [];
     OO.Analytics.FrameworkInstanceList = [];
+    OO.Analytics.Framework.TEST = undefined;
     //return log back to normal
     OO.log = console.log;
   };
@@ -228,6 +229,14 @@ describe('Analytics Framework Unit Tests', function()
       expect(typeof pluginID === 'string').toBe(true);
       var pluginList = framework.getPluginIDList();
       expect(pluginList.length).toEqual(1);
+    });
+
+    it('Test Factory Receives Framework Instance as param', function()
+    {
+      var goodFactory = Utils.createFactoryToTestConstructorParams();
+      var pluginID = framework.registerPlugin(goodFactory);
+      expect(OO.Analytics.Framework.TEST.frameworkParam).not.toBeNull();
+      expect(OO.Analytics.Framework.TEST.frameworkParam.getRecordedEvents()).toEqual([]);
     });
 
     it('Test Registering Same Good Factory Multiple Times', function()


### PR DESCRIPTION
AnalyticsPluginTemplate was not being passed the framework instance during construction. Therefore you couldn't get the list of events that were recorded.  Fixing that and adding unit test.