### PR TITLE
Nielsen stop on pause

### DIFF
--- a/js/plugins/Nielsen.js
+++ b/js/plugins/Nielsen.js
@@ -266,6 +266,10 @@ var NielsenAnalyticsPlugin = function (framework)
         {
           trackContentPause();
         }
+        else
+        {
+          trackAdPause();
+        }
         break;
       case OO.Analytics.EVENTS.VIDEO_REPLAY_REQUESTED:
         resetPlaybackState();
@@ -435,10 +439,20 @@ var NielsenAnalyticsPlugin = function (framework)
   {
     var reportedPlayhead = Math.floor(currentPlayhead);
     OO.log("Nielsen Tracking: stop from content pause with playhead " + reportedPlayhead);
-    //Report a final SET_PLAYHEAD_POSITION so the SDK reports the final second (it may miss
-    //the final second due to the 1 second intervals between reporting playheads)
-    notifyNielsen(DCR_EVENT.SET_PLAYHEAD_POSITION, reportedPlayhead);
     notifyNielsen(DCR_EVENT.STOP, reportedPlayhead);
+  };
+
+  /**
+   * To be called when an ad has been paused. Will notify the Nielsen SDK of a stop event
+   * (event 7).
+   * @private
+   * @method NielsenAnalyticsPlugin#trackAdPause
+   */
+  var trackAdPause = function()
+  {
+    var reportedAdPlayhead = Math.floor(currentAdPlayhead);
+    OO.log("Nielsen Tracking: stop from ad pause with ad playhead " + reportedAdPlayhead);
+    notifyNielsen(DCR_EVENT.STOP, reportedAdPlayhead);
   };
 
   /**

--- a/js/plugins/Nielsen.js
+++ b/js/plugins/Nielsen.js
@@ -261,6 +261,12 @@ var NielsenAnalyticsPlugin = function (framework)
         mainContentStarted = true;
         trackPlay();
         break;
+      case OO.Analytics.EVENTS.VIDEO_PAUSED:
+        if (!inAdBreak)
+        {
+          trackContentPause();
+        }
+        break;
       case OO.Analytics.EVENTS.VIDEO_REPLAY_REQUESTED:
         resetPlaybackState();
         //TODO: Unit test and dev test
@@ -417,6 +423,22 @@ var NielsenAnalyticsPlugin = function (framework)
       OO.log("Nielsen Tracking: loadMetadata from content play with playhead " + currentPlayhead);
       notifyNielsen(DCR_EVENT.LOAD_METADATA, contentMetadata);
     }
+  };
+
+  /**
+   * To be called when the main content has been paused. Will notify the Nielsen SDK of a stop event
+   * (event 7).
+   * @private
+   * @method NielsenAnalyticsPlugin#trackContentPause
+   */
+  var trackContentPause = function()
+  {
+    var reportedPlayhead = Math.floor(currentPlayhead);
+    OO.log("Nielsen Tracking: stop from content pause with playhead " + reportedPlayhead);
+    //Report a final SET_PLAYHEAD_POSITION so the SDK reports the final second (it may miss
+    //the final second due to the 1 second intervals between reporting playheads)
+    notifyNielsen(DCR_EVENT.SET_PLAYHEAD_POSITION, reportedPlayhead);
+    notifyNielsen(DCR_EVENT.STOP, reportedPlayhead);
   };
 
   /**


### PR DESCRIPTION
The plugin will now send a STOP event for pauses. Note that currently the Analytics Framework does not receive pause events for ads, so this functionality does not work. Content pauses work fine.