### PR TITLE
[template_live_flag]

### DIFF
--- a/js/plugins/AnalyticsPluginTemplate.js
+++ b/js/plugins/AnalyticsPluginTemplate.js
@@ -11,7 +11,6 @@ var AnalyticsPluginTemplate = function (framework)
   var name = "template";
   var version = "v1";
   var id;
-  var _active = true;
 
   /**
    * [Required Function] Return the name of the plugin.
@@ -95,6 +94,19 @@ var AnalyticsPluginTemplate = function (framework)
   this.processEvent = function(eventName, params)
   {
     OO.log( "Analytics Template: PluginID \'" + id + "\' received this event \'" + eventName + "\' with these params:", params);
+    switch(eventName)
+    {
+      case OO.Analytics.EVENTS.STREAM_TYPE_UPDATED:
+        if (params && params[0])
+        {
+          //Retrieve the stream type here.
+          //Possible values include OO.Analytics.STREAM_TYPE.VOD and OO.Analytics.STREAM_TYPE.LIVE_STREAM
+          var streamType = params[0].streamType;
+        }
+        break;
+      default:
+        break;
+    }
   };
 
   /**

--- a/js/plugins/conviva.js
+++ b/js/plugins/conviva.js
@@ -189,7 +189,7 @@ var ConvivaAnalyticsPlugin = function(framework)
   var tryBuildConvivaContentMetadata = function()
   {
     var success = false;
-    if (videoContentMetadata && embedCode && convivaClient)
+    if (videoContentMetadata && embedCode && convivaClient && streamType)
     {
       // Detach previous session if necessary
       clearLastSession();
@@ -422,7 +422,13 @@ var ConvivaAnalyticsPlugin = function(framework)
         trackAdEnd();
         break;
       case OO.Analytics.EVENTS.STREAM_TYPE_UPDATED:
-        var streamType = params[0].streamType;
+        if (params && params[0])
+        {
+          //Retrieve the stream type here.
+          //Possible values include OO.Analytics.STREAM_TYPE.VOD and OO.Analytics.STREAM_TYPE.LIVE_STREAM
+          streamType = params[0].streamType;
+          tryBuildConvivaContentMetadata();
+        }
         break;
       case OO.Analytics.EVENTS.VIDEO_STREAM_BITRATE_CHANGED:
         if (params && params[0] && _.isNumber(params[0].bitrate))

--- a/test/unit-test-helpers/AnalyticsFrameworkTestUtils.js
+++ b/test/unit-test-helpers/AnalyticsFrameworkTestUtils.js
@@ -211,6 +211,10 @@ if (!OO.Analytics.Utils)
           title: metadata.title,
           duration: metadata.duration
         }]);
+        var streamType = metadata.streamType ? metadata.streamType : OO.Analytics.STREAM_TYPE.VOD;
+        plugin.processEvent(OO.Analytics.EVENTS.STREAM_TYPE_UPDATED, [{
+          streamType: streamType
+        }]);
       }
     };
 

--- a/test/unit-tests/testConviva.js
+++ b/test/unit-tests/testConviva.js
@@ -156,7 +156,44 @@ describe('Analytics Framework Conviva Plugin Unit Tests', function() {
     });
     //asset name format is defined as "[" + embedCode + "] " + title in conviva.js and Conviva's sample app
     expect(Conviva.currentContentMetadata.assetName).toBe("[" + embedCode + "] " + title);
+    //default to VOD
     expect(Conviva.currentContentMetadata.streamType).toBe(Conviva.ContentMetadata.StreamType.VOD);
+    expect(Conviva.currentContentMetadata.duration).toBe(60);
+  });
+
+  it('Conviva Plugin can provide content metadata to Conviva with explicit VOD stream type',function()
+  {
+    var plugin = createPlugin(framework);
+    var simulator = Utils.createPlaybackSimulator(plugin);
+    var embedCode = "testEmbedCode";
+    var title = "testTitle";
+    simulator.simulatePlayerLoad({
+      embedCode: embedCode,
+      title: title,
+      duration: 60000,
+      streamType: OO.Analytics.STREAM_TYPE.VOD
+    });
+    //asset name format is defined as "[" + embedCode + "] " + title in conviva.js and Conviva's sample app
+    expect(Conviva.currentContentMetadata.assetName).toBe("[" + embedCode + "] " + title);
+    expect(Conviva.currentContentMetadata.streamType).toBe(Conviva.ContentMetadata.StreamType.VOD);
+    expect(Conviva.currentContentMetadata.duration).toBe(60);
+  });
+
+  it('Conviva Plugin can provide live content metadata to Conviva',function()
+  {
+    var plugin = createPlugin(framework);
+    var simulator = Utils.createPlaybackSimulator(plugin);
+    var embedCode = "testEmbedCode";
+    var title = "testTitle";
+    simulator.simulatePlayerLoad({
+      embedCode: embedCode,
+      title: title,
+      duration: 60000,
+      streamType: OO.Analytics.STREAM_TYPE.LIVE_STREAM
+    });
+    //asset name format is defined as "[" + embedCode + "] " + title in conviva.js and Conviva's sample app
+    expect(Conviva.currentContentMetadata.assetName).toBe("[" + embedCode + "] " + title);
+    expect(Conviva.currentContentMetadata.streamType).toBe(Conviva.ContentMetadata.StreamType.LIVE);
     expect(Conviva.currentContentMetadata.duration).toBe(60);
   });
 


### PR DESCRIPTION
-fixed an issue in Conviva where stream type was not considered before building conviva content metadata
-added a segment in the template to showcase how to get the stream type