### PR TITLE
Adding the ability to send both Live and VOD analytics data separately.

### DIFF
--- a/js/plugins/omniture.js
+++ b/js/plugins/omniture.js
@@ -353,6 +353,11 @@ var OmnitureAnalyticsPlugin = function (framework)
           }
         }
         break;
+      case OO.Analytics.EVENTS.STREAM_TYPE_UPDATED:
+        if (params && params[0])
+        {
+          playerDelegate.onStreamTypeUpdated(params[0].streamType);
+        }
       default:
         break;
     }
@@ -647,10 +652,14 @@ var OoyalaPlayerDelegate = function()
     videoInfo.id = id;
     videoInfo.name = name;
     videoInfo.length = length;
-    //TODO: StreamType and update unit test
-    //The type of the video asset, one of the following: AssetType.ASSET_TYPE_LIVE,
-    //AssetType.ASSET_TYPE_LINEAR, AssetType.ASSET_TYPE_VOD
-    videoInfo.streamType = ADB.va.plugins.videoplayer.AssetType.ASSET_TYPE_VOD;
+    if (streamType === OO.Analytics.STREAM_TYPE.LIVE_STREAM) {
+      videoInfo.streamType = ADB.va.plugins.videoplayer.AssetType.ASSET_TYPE_LIVE;
+    } else if (streamType === OO.Analytics.STREAM_TYPE.VOD) {
+      videoInfo.streamType = ADB.va.plugins.videoplayer.AssetType.ASSET_TYPE_VOD;
+    }else{
+   	//default streamType 
+      videoInfo.streamType = ADB.va.plugins.videoplayer.AssetType.ASSET_TYPE_VOD;
+    }
     videoInfo.playerName = playerName;
     videoInfo.playhead = streamPlayhead;
     return videoInfo;
@@ -725,6 +734,10 @@ var OoyalaPlayerDelegate = function()
   {
     //TODO: QOS info if/when available
    return null;
+  };
+  this.onStreamTypeUpdated = function(type)
+  {
+    streamType = type;
   };
 };
 

--- a/test/unit-tests/testOmniture.js
+++ b/test/unit-tests/testOmniture.js
@@ -264,7 +264,7 @@ describe('Analytics Framework Omniture Plugin Unit Tests', function()
     expect(videoInfo.playerName).toBe(playerName);
     expect(videoInfo.playhead).toBe(10);
   });
-it('Delegate can provide Video Info with VOD as the default streamType', function()
+  it('Delegate can provide Video Info with VOD as the default streamType', function()
   {
     var plugin = createPlugin(framework);
     var simulator = Utils.createPlaybackSimulator(plugin);
@@ -285,7 +285,7 @@ it('Delegate can provide Video Info with VOD as the default streamType', functio
     expect(videoInfo.playerName).toBe(playerName);
     expect(videoInfo.playhead).toBe(10);
   });
-it('Delegate can provide Video Info with VOD as the streamType', function()
+  it('Delegate can provide Video Info with VOD as the streamType', function()
   {
     var plugin = createPlugin(framework);
     var simulator = Utils.createPlaybackSimulator(plugin);
@@ -308,7 +308,7 @@ it('Delegate can provide Video Info with VOD as the streamType', function()
     expect(videoInfo.playhead).toBe(10);
   });
 
-it('Delegate can provide Video Info with LIVE as the streamType', function()
+  it('Delegate can provide Video Info with LIVE as the streamType', function()
   {
     var plugin = createPlugin(framework);
     var simulator = Utils.createPlaybackSimulator(plugin);

--- a/test/unit-tests/testOmniture.js
+++ b/test/unit-tests/testOmniture.js
@@ -308,7 +308,7 @@ it('Delegate can provide Video Info with VOD as the streamType', function()
     expect(videoInfo.playhead).toBe(10);
   });
 
-it('Delegate can provide Video Info with VOD as the default streamType', function()
+it('Delegate can provide Video Info with LIVE as the streamType', function()
   {
     var plugin = createPlugin(framework);
     var simulator = Utils.createPlaybackSimulator(plugin);

--- a/test/unit-tests/testOmniture.js
+++ b/test/unit-tests/testOmniture.js
@@ -264,6 +264,72 @@ describe('Analytics Framework Omniture Plugin Unit Tests', function()
     expect(videoInfo.playerName).toBe(playerName);
     expect(videoInfo.playhead).toBe(10);
   });
+it('Delegate can provide Video Info with VOD as the default streamType', function()
+  {
+    var plugin = createPlugin(framework);
+    var simulator = Utils.createPlaybackSimulator(plugin);
+    simulator.simulatePlayerLoad({
+      embedCode : "abcde",
+      title : "testTitle",
+      duration : 20000
+    });
+    simulator.simulateVideoProgress({
+      playheads: [10]
+    });
+    var delegate = plugin.getPlayerDelegate();
+    var videoInfo = delegate.getVideoInfo();
+    expect(videoInfo.id).toBe("abcde");
+    expect(videoInfo.name).toBe("testTitle");
+    expect(videoInfo.streamType).toBe(ADB.va.plugins.videoplayer.AssetType.ASSET_TYPE_VOD);
+    expect(videoInfo.length).toBe(20);
+    expect(videoInfo.playerName).toBe(playerName);
+    expect(videoInfo.playhead).toBe(10);
+  });
+it('Delegate can provide Video Info with VOD as the streamType', function()
+  {
+    var plugin = createPlugin(framework);
+    var simulator = Utils.createPlaybackSimulator(plugin);
+    simulator.simulatePlayerLoad({
+      embedCode : "abcde",
+      title : "testTitle",
+      streamType : OO.Analytics.STREAM_TYPE.VOD,
+      duration : 20000
+    });
+    simulator.simulateVideoProgress({
+      playheads: [10]
+    });
+    var delegate = plugin.getPlayerDelegate();
+    var videoInfo = delegate.getVideoInfo();
+    expect(videoInfo.id).toBe("abcde");
+    expect(videoInfo.name).toBe("testTitle");
+    expect(videoInfo.streamType).toBe(ADB.va.plugins.videoplayer.AssetType.ASSET_TYPE_VOD);
+    expect(videoInfo.length).toBe(20);
+    expect(videoInfo.playerName).toBe(playerName);
+    expect(videoInfo.playhead).toBe(10);
+  });
+
+it('Delegate can provide Video Info with VOD as the default streamType', function()
+  {
+    var plugin = createPlugin(framework);
+    var simulator = Utils.createPlaybackSimulator(plugin);
+    simulator.simulatePlayerLoad({
+      embedCode : "abcde",
+      title : "testTitle",
+      streamType:OO.Analytics.STREAM_TYPE.LIVE_STREAM,
+      duration : 20000
+    });
+    simulator.simulateVideoProgress({
+      playheads: [10]
+    });
+    var delegate = plugin.getPlayerDelegate();
+    var videoInfo = delegate.getVideoInfo();
+    expect(videoInfo.id).toBe("abcde");
+    expect(videoInfo.name).toBe("testTitle");
+    expect(videoInfo.streamType).toBe(ADB.va.plugins.videoplayer.AssetType.ASSET_TYPE_LIVE);
+    expect(videoInfo.length).toBe(20);
+    expect(videoInfo.playerName).toBe(playerName);
+    expect(videoInfo.playhead).toBe(10);
+  });
 
   it('Delegate can provide valid Ad Break Info', function()
   {


### PR DESCRIPTION
Just adding unit tests to the pull request #90 , 