### PR TITLE
[PLAYER-2104] Removing unnecessary reference to InitOOJQuery

### DIFF
--- a/test/unit-test-helpers/test_env.js
+++ b/test/unit-test-helpers/test_env.js
@@ -29,6 +29,5 @@ OO.log = console.log;
 // In a browser environment, all of the properties of "window" (like navigator) are in the global scope:
 OO._.extend(global, window);
 
-require.requireActual(COMMON_SRC_ROOT + "utils/InitModules/InitOOJQuery.js"); //this needs to come after the extend(global, window) line above otherwise $ gets set to undefined.
 require.requireActual(COMMON_SRC_ROOT + "utils/InitModules/InitOOHazmat.js");
 require.requireActual(COMMON_SRC_ROOT + "utils/InitModules/InitOOPlayerParamsDefault.js");


### PR DESCRIPTION
`InitOOJQuery` will be deprecated. See comments on main PR:

https://github.com/ooyala/html5-ad-plugins/pull/247