### PR TITLE
Fix/player 5259

### DIFF
--- a/js/plugins/iq.js
+++ b/js/plugins/iq.js
@@ -609,13 +609,10 @@ var IqPlugin= function (framework)
       case OO.Analytics.EVENTS.PLAYBACK_START_ERROR:
       case OO.Analytics.EVENTS.PLAYBACK_MIDSTREAM_ERROR:
       case OO.Analytics.EVENTS.PLUGIN_LOADED:
-        if (params && params[0]) 
-        {
-          eventMetadata = params[0];
-          eventMetadata.qosEventName = eventName;
-          OO.log("IQ: Reported: reportCustomEvent() for event: " + eventName + " with args:" + JSON.stringify(eventMetadata));
-          this.ooyalaReporter.reportCustomEvent(eventName, eventMetadata);
-        }
+        eventMetadata = params && params[0] ? params[0] : {};
+        eventMetadata.qosEventName = eventName;
+        OO.log("IQ: Reported: reportCustomEvent() for event: " + eventName + " with args:" + JSON.stringify(eventMetadata));
+        this.ooyalaReporter.reportCustomEvent(eventName, eventMetadata);
         break;
       // OO.EVENTS.WILL_PLAY_ADS -> OO.Analytics.EVENTS.AD_BREAK_STARTED
       case OO.Analytics.EVENTS.AD_BREAK_STARTED:

--- a/js/plugins/iq.js
+++ b/js/plugins/iq.js
@@ -599,6 +599,7 @@ var IqPlugin= function (framework)
         break;
       //OO.EVENTS.BUFFERING -> OO.Analytics.EVENTS.VIDEO_BUFFERING_STARTED.
       case OO.Analytics.EVENTS.VIDEO_BUFFERING_STARTED: 
+      case OO.Analytics.EVENTS.VIDEO_BUFFERING_ENDED:
       case OO.Analytics.EVENTS.INITIAL_PLAY_STARTING:
       case OO.Analytics.EVENTS.PLAYBACK_READY:
       case OO.Analytics.EVENTS.API_ERROR:

--- a/test/unit-tests/testIq.js
+++ b/test/unit-tests/testIq.js
@@ -510,6 +510,20 @@ describe('Analytics Framework Template Unit Tests', function()
     expect(unitTestState.eventMetadata.position).toBe(testPosition);
   });
 
+  it ('IQ Plugin should report video buffering ended', function()
+  {
+    var eventName = OO.Analytics.EVENTS.VIDEO_BUFFERING_ENDED;
+    var plugin = createPlugin(framework);
+    var simulator = Utils.createPlaybackSimulator(plugin);
+
+    simulator.simulateVideoBufferingEnded();
+
+    var unitTestState = plugin.ooyalaReporter.unitTestState;
+    expect(unitTestState.reportCustomEventCalled).toBe(1);
+    expect(unitTestState.eventName).toBe(eventName);
+    expect(unitTestState.eventMetadata.qosEventName).toBe(eventName);
+  });
+
   it ('IQ Plugin should report initial play starting updates', function()
   {
     var eventName = OO.Analytics.EVENTS.INITIAL_PLAY_STARTING;


### PR DESCRIPTION
VIDEO_BUFFERING_ENDED wasn't reported for an unknown reason. Added it among with relevant unit test.
Also made reportCustomEvent sending data onto backend even if no additional params for the event (have no idea why it was prevented from sending with no params before; the event itself is important data and can be sufficient).