### PR TITLE
fix/PLAYER-5259 patched errors output to get stack shown; inserted OO.log before dependants

### DIFF
--- a/js/framework/AnalyticsFramework.js
+++ b/js/framework/AnalyticsFramework.js
@@ -725,7 +725,8 @@ OO.Analytics.Framework = function()
       {
         if (plugin && _.isFunction(plugin.getName))
         {
-          OO.log(createErrorString("Error occurred during call to function \'" + funcName + "\' on plugin \'" + plugin.getName() + "\'\n", err));
+          OO.log(createErrorString("Error occurred during call to function \'" + funcName + "\' on plugin \'" + plugin.getName() + "\'\n"));
+          OO.log(err);
         }
       }
       catch(e)

--- a/test/unit-tests/testIq.js
+++ b/test/unit-tests/testIq.js
@@ -15,9 +15,10 @@ describe('Analytics Framework Template Unit Tests', function()
   //setup for individual tests
   var testSetup = function()
   {
+    // mute the logging becuase there will be lots of error messages
+    // @TODO: muting errors is inacceptable; errors throwing strategy should be reconsidered
+    OO.log = () => {};
     framework = new Analytics.Framework();
-    //mute the logging becuase there will be lots of error messages
-    OO.log = function(){};
     OO.VERSION = { core : { releaseVersion : "v4"} };
 
     window.Ooyala = {


### PR DESCRIPTION
This PR fixes tests in two places: makes error.stack to get logged (previously converted into empty string); creates OO.log mock before it's called.
Errors muting elimination tech debt task created: https://jira.corp.ooyala.com/browse/PLAYER-5267